### PR TITLE
Added pullToRefresh Feature

### DIFF
--- a/app/src/main/java/com/ramonaharrison/dev/dreamteamnow/CardAdapter.java
+++ b/app/src/main/java/com/ramonaharrison/dev/dreamteamnow/CardAdapter.java
@@ -3,6 +3,7 @@ package com.ramonaharrison.dev.dreamteamnow;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.support.v7.internal.view.menu.MenuView;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -31,13 +32,20 @@ public class CardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     // TODO: add an int value for each card type
     private final int TODO = 1;
-    final int WEATHER = 2;
+    private final int WEATHER = 2;
     private final int MAP = 692;
     private final int TREND = 11;
+
+    private View mapItemView;
 
     public CardAdapter(List<CardInfo> cardList, Context context) {
         this.cardList = cardList;
         this.context = context;
+    }
+
+    public CardAdapter(List<CardInfo> cardList, Context context, View mapItemView){
+        this(cardList, context);
+        this.mapItemView = mapItemView;
     }
 
 
@@ -172,11 +180,17 @@ public class CardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
          }
 
         if (viewType == MAP) {
-            View itemView = LayoutInflater.
-                    from(parent.getContext()).
-                    inflate(R.layout.map_card, parent, false);
+            if(mapItemView == null){
+                View itemView = LayoutInflater.
+                        from(parent.getContext()).
+                        inflate(R.layout.map_card, parent, false);
+                MainActivity.setMapItemView(itemView);
 
-            return new MapViewHolder(itemView);
+                return new MapViewHolder(itemView);
+            }else{
+                return new MapViewHolder(mapItemView);
+            }
+
         }
 
         return null;

--- a/app/src/main/java/com/ramonaharrison/dev/dreamteamnow/TrendInfo.java
+++ b/app/src/main/java/com/ramonaharrison/dev/dreamteamnow/TrendInfo.java
@@ -84,6 +84,6 @@ public void getNewsData(){
 
             }
         };
-        new Handler().postDelayed(runnable,2000);
+        new Handler().postDelayed(runnable,3000);
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,11 +8,18 @@
     tools:context=".MainActivity">
 
 
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/swipe_refresh">
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/cardList"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />
+
+    </android.support.v4.widget.SwipeRefreshLayout>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/actionButton"


### PR DESCRIPTION
- Pull to refresh works
  - It re-initializes the cards List, creates a new adapter, and swaps the old adapter with the new one.

Notes:
- if your card needs a progress bar or loading animation you still need to implement that as this simply just sets a new adapter.
- @ramonaharrison - Since inflating the map layout crashes when inflating the fragment for the second time, I had to save the first inflated map itemView that was created for use in the new adapters that get created. Check out the code and let me know if my solution is an okay work around.
- @KMaragh - I added an extra second to your postDelayed on the handler since it didn't load. Also if it doesn't load on top it crashes the entire app so maybe a try catch with an error message inside your card would be a good idea there.

Things that can be improved:
- If last refresh was within x seconds/minutes don't refresh (this can save api calls if needed but not priority for demo purposes)
